### PR TITLE
Resolve DeprecationWarnings in utils.py

### DIFF
--- a/alaska/utils.py
+++ b/alaska/utils.py
@@ -20,7 +20,7 @@ import gzip
 
 plt.switch_backend("agg")
 
-word_detector = re.compile("\w")
+word_detector = re.compile(r"\w")
 
 
 class Vocab(object):

--- a/utils.py
+++ b/utils.py
@@ -20,7 +20,7 @@ import gzip
 
 plt.switch_backend("agg")
 
-word_detector = re.compile("\w")
+word_detector = re.compile(r"\w")
 
 
 class Vocab(object):


### PR DESCRIPTION
#### Description:
Resolve "DeprecationWarning: invalid escape sequence \w".
Change utils.py's re.compile statements to use raw strings: re.compile(r"\w").

#### To reproduce the issue
The DeprecationWarning can be seen when running pytest
```
pytest
...
alaska/tests/test_parser.py::test_model_parse
  /usr/local/devel/MyWrk/geo-wrk/alaska/alaska/utils.py:23: 
  DeprecationWarning: invalid escape sequence \w
      word_detector = re.compile("\w")

alaska/utils.py:23
  /usr/local/devel/MyWrk/geo-wrk/alaska/alaska/alaska/utils.py:23: DeprecationWarning: invalid escape sequence \w
      word_detector = re.compile("\w")
...
```

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [X] Run `black .` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
