### PR TITLE
Issue-16: Update alias counting for parsing methods 

### DIFF
--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -296,17 +296,20 @@ class Alias:
         )
         print("Alasing with dictionary...")
         dic = df.apply(lambda x: x.astype(str).str.lower())
-        index = 0
-        for i in mnem:
-            if i in dic.mnemonics.unique():
-                key = dic.loc[dic["mnemonics"] == i, "label"].iloc[0]  # can be reduced?
-                self.output[i] = key
+        aliased = 0
+        for index, word in enumerate(mnem):
+            if word in dic.mnemonics.unique():
+                # can be reduced?
+                key = dic.loc[dic["mnemonics"] == word, "label"].iloc[0]
+                self.output[word] = key
                 self.duplicate.append(index)
-                self.mnem.append(i)
+                self.mnem.append(word)
                 self.probability.append(1)
                 self.method.append("dictionary")
-            index += 1
-        print("Aliased {} mnemonics with dictionary".format(index - 1))
+                aliased += 1
+            else:
+                self.not_found.append(word)
+        print("Aliased {} mnemonics with dictionary".format(aliased))
 
     def keyword_parse(self, mnem, desc):
         """
@@ -318,19 +321,22 @@ class Alias:
         Tree = make_tree()
         new_desc = [v for i, v in enumerate(desc) if i not in self.duplicate]
         new_mnem = [v for i, v in enumerate(mnem) if i not in self.duplicate]
-        index = 0
+        aliased = 0
         print("Alasing with keyword extractor...")
-        for i in new_desc:
-            key = search(Tree, i)
+        for index, word in enumerate(new_desc):
+            key = search(Tree, word)
             if key == None:
-                self.not_found.append(new_mnem[index])
+                if new_mnem[index] not in self.not_found:
+                    self.not_found.append(new_mnem[index])
             else:
                 self.output[new_mnem[index]] = key
                 self.mnem.append(new_mnem[index])
                 self.probability.append(1)
                 self.method.append("keyword")
-            index += 1
-        print("Aliased {} mnemonics with keyword extractor".format(index - 1))
+                if new_mnem[index] in self.not_found:
+                    self.not_found.remove(new_mnem[index])
+                aliased += 1
+        print("Aliased {} mnemonics with keyword extractor".format(aliased))
 
     def model_parse(self, df):
         """

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -42,7 +42,7 @@ def test_parse():  # 1000080059
     assert result == ({"depth": ["DEPT"], "gamma ray": ["GR"]}, [])
 
 
-def test_dictionary_parse():
+def test_dictionary_parse_1():
     """
     Test that dictionary parser in Aliaser parses and returns correct labels
     """
@@ -51,13 +51,64 @@ def test_dictionary_parse():
     assert result == ({"depth": ["DEPT"], "gamma ray": ["GR"]}, [])
 
 
-def test_keyword_parse():  # 3725733C.las
+def test_dictionary_parse_3():
+    """
+    Test that dictionary parser in Aliaser parses and returns correct labels
+    with one item aliased and one item not aliased.
+    """
+    aliaser = Alias(keyword_extractor=False, model=False)
+    aliased, not_aliased = aliaser.parse(test_case_3)
+
+    assert len(aliased) == 1
+    assert "density porosity" in aliased
+    assert len(not_aliased) == 1
+    assert "qn" in not_aliased
+
+
+def test_keyword_parse_1():
+    """
+    Test that keyword parser in Aliaser parses and returns correct labels
+    """
+    aliaser = Alias(dictionary=False, model=False)
+    aliased, not_aliased = aliaser.parse(test_case_1)
+
+    assert len(aliased) == 1
+    assert "gamma ray" in aliased
+    assert len(not_aliased) == 1
+    assert "dept" in not_aliased
+
+
+def test_keyword_parse_2():  # 3725733C.las
     """
     Test that keyword parser in Aliaser parses and returns correct labels
     """
     aliaser = Alias(dictionary=False, model=False)
     result = aliaser.parse(test_case_2)
     assert result == ({"density porosity": ["DPHI"], "caliper": ["CALI"]}, [])
+
+
+def test_dictionary_and_keyword_parse_1():
+    """
+    Test that keyword parser in Aliaser parses and returns correct labels
+    """
+    aliaser = Alias(model=False)
+    aliased, not_aliased = aliaser.parse(test_case_1)
+
+    assert aliased == {"depth": ["DEPT"], "gamma ray": ["GR"]}
+    assert len(not_aliased) == 0
+
+
+def test_dictionary_and_keyword_parse_3():
+    """
+    Test that keyword parser in Aliaser parses and returns correct labels
+    """
+    aliaser = Alias(model=False)
+    aliased, not_aliased = aliaser.parse(test_case_3)
+
+    assert len(aliased) == 1
+    assert "density porosity" in aliased
+    assert len(not_aliased) == 1
+    assert "qn" in not_aliased
 
 
 def test_model_parse():
@@ -75,4 +126,4 @@ def test_make_prediction():
     """
     result = make_prediction(test_case_4)
     assert result[0] == {"qn": "near quality"}
-    assert result[1]['qn'] == pytest.approx(0.8421125945781427, rel=1e-4) 
+    assert result[1]["qn"] == pytest.approx(0.8421125945781427, rel=1e-4)


### PR DESCRIPTION
#### Description:
This  pull-request is a solution for #16 `keyword extractor counter`

Fixes #16 `keyword extractor counter`

#### Summary:
Update alias counting for parsing methods
- Update the alias counting for the dictionary_parse() and keyword_parse() methods.
- Separate duplicate counting from alias counting
- Update the not_found list in dictionary_parse() to that it reports not_founds when running as the only parser
- Add tests for various alias counting variations

#### Changes
- In `dictionary_parse()` and keyword_parse() separate the duplicate count from the aliased count because they count slightly different things.  The duplicate count seems to be tracking the index location in the `mnem` variable for Mnemonic with a found alias.  The Aliased count is tracking the number of Mnemonics for which an alias was found.
- Add registering not_found mnemonics in dictionary_parse().
- Add removing not_found mnemonics if found with keyword_parse()
- Added 3 tests to test various combinations of running dictionary_parse() and keyword_parse().

#### Testing:

All tests pass when running `pytest`


**Reminders**

- [X] Run `black .` to make sure the code follows the style guide.
- [X] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.


Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC