### PR TITLE
Add keyword_tree tests

### DIFF
--- a/alaska/data/testcase5.las
+++ b/alaska/data/testcase5.las
@@ -1,0 +1,21 @@
+~VERSION INFORMATION
+ VERS.                                2.0: CWLS LOG ASCII STANDARD - VERSION 2
+ WRAP.                                 NO: One line per depth step
+~Well Information Block
+#MNEM.UNIT              Information: Data type
+#---------  -----------------------  ---------
+ DATE.                                   : LOG DATE
+ API .                                   : API Well Number
+~Curve Information Block
+#MNEM.UNIT                            No  Description
+#---------                            --  -----------
+ DEPT.F                                  : 1  Depth Curve
+ GR  .GAPI                               : 2  GAMMA RAY
+ EMPTY.                                  :
+~Parameter Information Block
+#MNEM.UNIT                   Value : Description
+#--------- ------------------------  -----------
+ EKB .FT                             2389: ELEVATION, KELLY BUSHING
+ DL  .FT                           1748.0: DEPTH LOGGER
+ CS  .IN                            8 5/8: CASING SIZE
+ CD  .FT                              280: CASING DEPTH LOGGER

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -69,7 +69,6 @@ def test_parse_2():
     Test that Aliaser can parse las file with an empty mnemonic
     """
     aliaser = Alias()
-    # import pdb; pdb.set_trace()
     result = aliaser.parse(test_case_5)
     assert result == ({"depth": ["DEPT"], "gamma ray": ["GR"]}, ["empty"])
 

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -78,13 +78,20 @@ def test_parse_directory_1():
     """
     Test that Aliaser can parse a directory of las files
     """
-    expect_aliased = ["depth", "gamma ray", "density porosity", "caliper"]
-    expect_not_aliased = ["empty", "qn"]
-
     aliaser = Alias()
     aliased, not_aliased = aliaser.parse_directory(test_dir_1)
-    assert list(aliased) == expect_aliased
-    assert not_aliased == expect_not_aliased
+    have1 = aliased.get("density porosity", None)
+    have2 = aliased.get("depth", None)
+    have3 = aliased.get("gamma ray", None)
+
+    # Aliased
+    assert have1 == ["DPHI"]
+    assert have2 == ["DEPT"]
+    assert have3 == ["GR"]
+
+    # Not Aliased
+    assert "qn" in not_aliased
+    assert "empty" in not_aliased
 
 
 def test_parse_directory_2():
@@ -92,11 +99,10 @@ def test_parse_directory_2():
     Test that Aliaser can parse a directory of las files and use the model
     parser
     """
-    # aliaser = Alias()
     aliaser = Alias(dictionary=False, keyword_extractor=False, model=True)
     aliased, not_aliased = aliaser.parse_directory(test_dir_1)
-    have1 = aliased.get("density porosity", "")
-    have2 = aliased.get("medium conductivity", "")
+    have1 = aliased.get("density porosity", None)
+    have2 = aliased.get("medium conductivity", None)
     assert have1 == ["DPHI"]
     assert have2 == ["DEPT"]
     assert "empty" in not_aliased


### PR DESCRIPTION
#### Description:
Add test cases for alaska/keyword_tree.py in alaska/tests/test_parser.py


-  test_search_child_2() : Test that search of empty nodes returns None
- test_search_child_3() : Test that search nodes for an non-existent description returns None: 
- test_parse_2() : Test that Aliaser can parse las file with an empty mnemonic
- test_parse_directory_1() : Test that Aliaser can parse a directory of las files
- test_parse_directory_2() : Test that Aliaser can parse a directory of las files and use the model parser

#### Related Issue:
This work is a subset of #26 Increase test coverage, but does not complete it.


**Reminders**

- [x] Run `black .` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC