### PR TITLE
Add additional tests to test_parser

### DIFF
--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -353,6 +353,8 @@ class Alias:
                 self.mnem.append(key)
                 self.probability.append(float(value))
                 self.method.append("model")
+                if key in self.not_found:
+                    self.not_found.remove(key)
             else:
                 self.not_found.append(key)
         print("Aliased {} mnemonics with pointer generator".format(len(predicted_prob)))

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -152,6 +152,24 @@ def test_keyword_parse_2():  # 3725733C.las
     assert result == ({"density porosity": ["DPHI"], "caliper": ["CALI"]}, [])
 
 
+def test_keyword_parse_3():
+    """
+    Test that keyword parser in Aliaser successfully removes found items from
+    the not_found list
+    """
+    aliaser = Alias(dictionary=False, model=False)
+    aliaser.not_found.extend(["gr", "no such thing"])
+    found, not_found = aliaser.parse(test_case_5)
+
+    have1 = found.get("gamma ray", None)
+
+    assert have1 == ["GR"]
+    assert "gr" not in not_found
+    assert "gr" not in aliaser.not_found
+    assert "no such thing" in not_found
+    assert "no such thing" in aliaser.not_found
+
+
 def test_dictionary_and_keyword_parse_1():
     """
     Test that keyword parser in Aliaser parses and returns correct labels
@@ -183,6 +201,27 @@ def test_model_parse():
     aliaser = Alias(dictionary=False, keyword_extractor=False, model=True)
     result = aliaser.parse(test_case_3)
     assert result == ({"near quality": ["QN"], "density porosity": ["DPHI"]}, [])
+
+
+def test_model_parse_2():
+    """
+    Test that model in Aliaser parses and returns correct predictions and
+    removes found items from the not_found list
+
+    expected data
+    aliased == {"near quality": ["QN"], "density porosity": ["DPHI"]}
+    not_aliased == []
+    """
+    aliaser = Alias(dictionary=True, keyword_extractor=False, model=True)
+    aliased, not_aliased = aliaser.parse(test_case_3)
+
+    have1 = aliased.get("density porosity", None)
+    have2 = aliased.get("near quality", None)
+
+    assert have1 == ["DPHI"]
+    assert have2 == ["QN"]
+    assert "qn" not in not_aliased
+    assert "qn" not in aliaser.not_found
 
 
 def test_make_prediction():

--- a/tutorials/example.py
+++ b/tutorials/example.py
@@ -5,7 +5,7 @@ import lasio
 import pandas as pd
 
 
-path = = Path("alaska/data/testcase3.las")
+path = Path("alaska/data/testcase3.las")
 a = Alias()
 parsed, not_found = a.parse(path)
 las = lasio.read(path)


### PR DESCRIPTION
#### Description:

Add more test cases for alaska/keyword_tree.py in alaska/tests/test_parser.py

- Add tests that verify found items are removed from the Alias.not_found list
- Add removing found items from not_found in Alias.model_parse()
- Fix path assigment operator in example.py

#### Related issue:

This work is a subset of #26 'Increase test coverage', but does not complete it.

**Reminders**

- [X] Run `black .` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.


#### Test Results:

##### Before
```
Name                           Stmts   Miss  Cover
--------------------------------------------------
...
alaska/keyword_tree.py           292      9    97%
...
--------------------------------------------------
TOTAL                           1341    418    69%
```

##### After
```
Name                           Stmts   Miss  Cover
--------------------------------------------------
...
alaska/keyword_tree.py           294      4    99%
...
--------------------------------------------------
TOTAL                           1343    413    69%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC