### PR TITLE
Remove unused import from example.py

### DIFF
--- a/tutorials/example.py
+++ b/tutorials/example.py
@@ -1,9 +1,12 @@
-from predict_from_model import eval_bs, make_prediction
-from keyword_tree import Alias
+"""
+Example script demonstrating AlasKA parsing
+"""
 from pathlib import Path
+
 import lasio
 import pandas as pd
 
+from keyword_tree import Alias
 
 path = Path("alaska/data/testcase3.las")
 a = Alias()


### PR DESCRIPTION
These changes are minor improvements on tutorial/example.py
- Remove unused import from example.py
- Add script-level docstring
- Reorder imports to be standard python modules, dependency modules and
  then AlasKA modules

Fixes #
N/A

**Reminders**

- [X] Run `black .` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
