### PR TITLE
Fix KeyError in example.py

### DIFF
--- a/tutorials/example.py
+++ b/tutorials/example.py
@@ -15,16 +15,31 @@ a = Alias()
 parsed, not_found = a.parse(path)
 las = lasio.read(path)
 l, l2, l3 = [], [], []
-for key, value in parsed.items():
+
+for key, values in parsed.items():
     l.append(key)
-    l2.append(str(las.curves[key].descr))
-    l3.append(value)
+    for value in values:
+        for curve in las.curves:
+            if curve.mnemonic.lower() == value.lower():
+                l2.append(str(curve.descr))
+        l3.append(value)
+
 output_df = pd.DataFrame({"mnemonic": l, "description": l2, "parsed_mnemonic": l3})
+
+
 l, l2, l3, lst = [], [], [], []
 for i in not_found:
     l.append(i)
     l2.append(str(las.curves[i].descr))
     l3.append(str(las.curves[i].unit).lower())
 output_df2 = pd.DataFrame({"mnemonics": l, "description": l2, "units": l3})
+
+
+print("\n-----------------------------------------------------------")
+print("Found")
+print("-----------------------------------------------------------")
 print(output_df)
+print("\n-----------------------------------------------------------")
+print("Not-Found")
+print("-----------------------------------------------------------")
 print(output_df.loc[output_df["mnemonic"].isin(output_df2.mnemonics)])


### PR DESCRIPTION
#### Description:
This is a proposed fix for issue 42 : KeyError: tutorials/example.py

- Add looping through values list
- Add looping through las.curves list
- Compare curve.mnemonic to value and if they match add curve.descr to l2
- Add report headers to clarify output results

Fixes #42

#### Test results: (no change)

```
Name                           Stmts   Miss  Cover
--------------------------------------------------
alaska/__init__.py                 6      0   100%
alaska/_version.py               279    142    49%
alaska/get_data_path.py            7      2    71%
alaska/keyword_tree.py           297      4    99%
alaska/model.py                  303    115    62%
alaska/params.py                  56      0   100%
alaska/predict_from_model.py      86     23    73%
alaska/utils.py                  324    103    68%
--------------------------------------------------
TOTAL                           1358    389    71%
Coverage XML written to file coverage.xml
```

**Reminders**

- [X] Run `black .` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.


Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC