### PR TITLE
Fix data path for py3.9 updates

### DIFF
--- a/alaska/get_data_path.py
+++ b/alaska/get_data_path.py
@@ -4,6 +4,8 @@ location whether it is a regular package install (pip install alaska) or a
 developer/editable install from the alaska repo (pip install -e .)
 also see: https://importlib-resources.readthedocs.io/en/latest/
 """
+from alaska import data
+
 # Maintenance note:
 #    When Python 3.6 support ends, this try/except can be
 #   changed to simply `import importlib.resources as pkg_resources`
@@ -14,6 +16,14 @@ except ImportError:
     import importlib_resources as pkg_resources
 
 
-def get_data_path():
-    with pkg_resources.path("alaska", "data") as mypath:
+def get_data_path(datafile):
+    """
+    :param datafile: the file name of a file in the alaska.data module
+    :return: PosixPath() object containing the full path to the datafile
+
+    Build and return a path object for the input datafile
+
+    Example: get_data_path("my_wonderful.csv")
+    """
+    with pkg_resources.path(data, datafile) as mypath:
         return mypath

--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -14,8 +14,6 @@ from .get_data_path import get_data_path
 
 sns.set()
 
-alaska_data_path = get_data_path()
-
 
 class Node:
     """
@@ -34,7 +32,7 @@ def make_tree():
     Generates keyword extractor tree
     """
 
-    original_lowered_csv = os.path.join(alaska_data_path, "original_lowered.csv")
+    original_lowered_csv = get_data_path("original_lowered.csv")
 
     root = Node(None)
     df = (
@@ -307,9 +305,7 @@ class Alias:
         :return: None
         Find exact matches of mnemonics in mnemonic dictionary
         """
-        comprehensive_dictionary_csv = os.path.join(
-            alaska_data_path, "comprehensive_dictionary.csv"
-        )
+        comprehensive_dictionary_csv = get_data_path("comprehensive_dictionary.csv")
 
         df = (
             pd.read_csv(comprehensive_dictionary_csv)

--- a/tutorials/example.py
+++ b/tutorials/example.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from alaska import Alias, get_data_path
 
-path = Path(os.path.join(get_data_path(), "testcase3.las"))
+path = Path(get_data_path("testcase3.las"))
 
 a = Alias()
 parsed, not_found = a.parse(path)

--- a/tutorials/parse.py
+++ b/tutorials/parse.py
@@ -21,7 +21,7 @@ from welly import Project
 
 from alaska import Alias, get_data_path
 
-path = os.path.join(get_data_path(), "testcase1.las")
+path = str(get_data_path("testcase1.las"))
 
 
 # initialize aliaser


### PR DESCRIPTION
#### Description:

Updating the local python version to 3.9 reveals an error in the get_data_path() function.
```
python tutorial/example.py
TypeError: get_data_path() missing 1 required positional argument: 'datafile'``
```

This change updates the get_data_path() function work with Python 3.9
- Make alaska/data a module by adding __init__.py
- Use data module in importlib path command to retrieve the path of a passed in file in the data directory.


**Reminders**

- [X] Run `black .` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [X] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.

#### Testing:

This has be tested on dev-env and wheel packages for Python 3.6, 3.8 and Python 3.9 by running the pytest suite at the GIT_ROOT.

```
Name                           Stmts   Miss  Cover
--------------------------------------------------
alaska/__init__.py                 6      0   100%
alaska/_version.py               279    142    49%
alaska/data/__init__.py            0      0   100%
alaska/get_data_path.py            8      2    75%
alaska/keyword_tree.py           296      4    99%
alaska/model.py                  303    115    62%
alaska/params.py                  56      0   100%
alaska/predict_from_model.py      86     23    73%
alaska/utils.py                  324    103    68%
--------------------------------------------------
TOTAL                           1358    389    71%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC