### PR TITLE
Clean up predict_from_model

### DIFF
--- a/alaska/predict_from_model.py
+++ b/alaska/predict_from_model.py
@@ -31,6 +31,7 @@ def decode_batch_output(
         decoded_batch.append(decoded_doc)
     return decoded_batch
 
+
 def eval_bs_batch(
     batch: Batch,
     model: Seq2Seq,


### PR DESCRIPTION
Removed `decode_batch` and `decode_one` functions since they are used in training but not for inference. Could add a training module later on.

**Reminders**

- [x] Run `black .` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
