### PR TITLE
Parse dir

### DIFF
--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -266,7 +266,7 @@ class Alias:
         comprehensive_dict = {}
         comprehensive_not_found = []
         for filename in os.listdir(directory):
-            if filename.endswith(".las"):
+            if filename.endswith((".LAS",".las")):
                 path = os.path.join(directory, filename)
                 las = lasio.read(path)
                 mnem, desc = [], []

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -199,6 +199,15 @@ def test_parse_directory_2():
     assert "empty" in not_aliased
 
 
+def test_parse_directory_3():
+    """
+    Test that Aliaser can parse .LAS and .las
+    """
+    aliaser = Alias()
+    aliased, _ = aliaser.parse_directory(test_dir_1)
+    assert len(aliased.keys()) > 0
+
+
 def test_dictionary_parse_1():
     """
     Test that dictionary parser in Aliaser parses and returns correct labels


### PR DESCRIPTION
updated parse_directory so that capitalization in the file extension does not matter.

The `parse_directory` method was having issues with capitalization in the `LAS` file extensions. I changed the requirement from `.las` as a string to a tuple of `(".LAS", ".las")`. This appears to fix this issue at this time. All local tests are passing
Fixes #60


**Reminders**

- [x] Run `black .` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
