### PR TITLE
Directory Parse warning

### DIFF
--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -7,6 +7,7 @@ contains the keyword tree extractor and alias class
 import os.path
 import gzip
 import json
+import logging
 
 import pandas as pd
 import seaborn as sns
@@ -266,8 +267,13 @@ class Alias:
         comprehensive_dict = {}
         comprehensive_not_found = []
         for filename in os.listdir(directory):
-            if filename.endswith((".LAS",".las")):
+            if filename.endswith((".LAS", ".las")):
                 path = os.path.join(directory, filename)
+                try:
+                    las = lasio.read(path)
+                except:
+                    logging.warning(f"lasio was not able to parse {filename}")
+                    continue
                 las = lasio.read(path)
                 mnem, desc = [], []
                 for key in las.keys():

--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -272,7 +272,7 @@ class Alias:
                 try:
                     las = lasio.read(path)
                 except:
-                    logging.warning(f"lasio was not able to parse {filename}")
+                    logging.warning(f"lasio was not able to read {filename}")
                     continue
                 las = lasio.read(path)
                 mnem, desc = [], []

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -36,6 +36,7 @@ Tests for Alaska's parser classes and functions
 from pathlib import Path
 import matplotlib.pyplot as plt
 import pytest
+import logging
 from ..keyword_tree import Alias, search, make_tree, search_child, Node
 from ..predict_from_model import make_prediction
 from ..get_data_path import get_data_path
@@ -206,6 +207,15 @@ def test_parse_directory_3():
     aliaser = Alias()
     aliased, _ = aliaser.parse_directory(test_dir_1)
     assert len(aliased.keys()) > 0
+
+
+def test_parse_directory_4(caplog):
+    """
+    Test that Alias class returns a warning for empty LAS file
+    """
+    aliaser = Alias()
+    aliaser.parse_directory(test_dir_1)
+    assert "lasio was not able to read testcase6.LAS" in caplog.text
 
 
 def test_dictionary_parse_1():


### PR DESCRIPTION
Added a `logging.warning()` to the `parse_directory` method in the `Alias` class. This will print out the names of LAS files that `lasio` was not able to read and then continue reading the remaining LAS files in the directory and parsing the mnemonics. 

I am not sure if we should raise a warning for the `parse` method or just let `lasio` read/load error propagate through. 

Fixes #61 


**Reminders**

- [x] Run `black .` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
