### PR TITLE
Add new aliases to comprehensive dict

### DIFF
--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -253,7 +253,6 @@ class Alias:
         if self.model is True:
             df = self.make_df(path)
             self.model_parse(df)
-        # formatted_output = {}
         for key, val in self.output.items():
             self.formatted_output.setdefault(val, []).append(key.upper())
         return self.formatted_output, self.not_found
@@ -297,7 +296,6 @@ class Alias:
                 comprehensive_not_found.extend(self.not_found)
                 self.output = {}
                 self.duplicate, self.not_found = [], []
-        # formatted_output = {}
         for key, val in comprehensive_dict.items():
             self.formatted_output.setdefault(val, []).append(key.upper())
         return self.formatted_output, comprehensive_not_found

--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -484,12 +484,12 @@ class Alias:
         munge_df['label'] = not_in_comprehensive['label'].str.upper()
         appended_df = comprehensive_dictionary_csv.append(munge_df, ignore_index=True, verify_integrity=True)
         if not path:
-            appended_df.to_csv(get_data_path("comprehensive_dictionary.csv"), index=False)
+            appended_df.to_csv(get_data_path("comprehensive_dictionary.csv"), index=False, columns=['mnemonics', 'label'])
         else:
             if not path.endswith(".csv"):
                 raise IOError(
                 "Please check your file name type. Custom dictionary paths must end with .csv"
             )
             else:
-                appended_df.to_csv(path, index=False)
+                appended_df.to_csv(path, index=False, columns=['mnemonics', 'label'])
 

--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -484,12 +484,12 @@ class Alias:
         munge_df['label'] = not_in_comprehensive['label'].str.upper()
         appended_df = comprehensive_dictionary_csv.append(munge_df, ignore_index=True, verify_integrity=True)
         if not path:
-            appended_df.to_csv(get_data_path("comprehensive_dictionary.csv"))
+            appended_df.to_csv(get_data_path("comprehensive_dictionary.csv"), index=False)
         else:
             if not path.endswith(".csv"):
                 raise IOError(
                 "Please check your file name type. Custom dictionary paths must end with .csv"
             )
             else:
-                appended_df.to_csv(path)
+                appended_df.to_csv(path, index=False)
 

--- a/alaska/keyword_tree.py
+++ b/alaska/keyword_tree.py
@@ -205,11 +205,11 @@ def search_child(node, description):
 class Alias:
     """
     :param dictionary: boolean for dictionary aliasing
-    :param custom_dict: string path to a custom dictionary in either .json or .csv format
+    :param custom_dict: string path to a custom dictionary in either .json or .csv
     :param keyword_extractor: boolean for keyword extractor aliasing
     :param model: boolean for model aliasing
     :param prob_cutoff: probability cutoff for pointer generator model
-    :return: dictionary of mnemonics and labels, list of mnemonics that can't be aliased
+    :return: dictionary of mnemonics and labels, list of mnemonics not aliased
     Parses LAS file and returns parsed mnemonics with labels
     """
 
@@ -234,7 +234,7 @@ class Alias:
     def parse(self, path):
         """
         :param path: path to LAS file to be aliased
-        :return: dictionary of mnemonics and labels, list of mnemonics that can't be aliased
+        :return: dictionary of mnemonics and labels, list of mnemonics not aliased
         Parses LAS file and call parsers accordingly
         """
         las = lasio.read(path)
@@ -260,7 +260,7 @@ class Alias:
     def parse_directory(self, directory):
         """
         :param path: path to directory containing LAS files
-        :return: dictionary of mnemonics and labels, list of mnemonics that can't be aliased
+        :return: dictionary of mnemonics and labels, list of mnemonics not aliased
         Parses LAS files and call parsers accordingly
         """
         comprehensive_dict = {}
@@ -326,7 +326,7 @@ class Alias:
     def _file_type_check(self, file_path):
         """
         :param file_path: string filepath to dictionary either .json or .csv
-        Checks file path and converts json to lookup table, passes .csv to dictionary_parse
+        Checks file path converts json to lookup table, passes .csv to dictionary_parse
         """
         if os.path.isfile(file_path) and file_path.endswith(".json"):
             with open(file_path) as json_file:
@@ -468,26 +468,37 @@ class Alias:
             {"mnemonics": mnem, "description": description, "units": unit}
         )
         return output_df
+
     def add_to_dictionary(self, path=None):
         """
-        Adds new aliases from the pointer generator and keyword extractor to the comprehensive dictionary. By default it will overwrite the comprehensive dictionary
-        :param path: path to save the custom dictionary, default appends to the comprehensive dictionary
+        Adds new aliases from model and keyword extractor to comprehensive dictionary. 
+        By default it will overwrite the comprehensive dictionary
+        :param path: path to save custom dictionary, default appends comprehensive
         """
         if not self.formatted_output:
-            raise ValueError('The alias dictionary is empty. Please parse a LAS file')
+            raise ValueError("The alias dictionary is empty. Please parse a LAS file")
         new_aliases = self._dict_to_table(dicts=self.formatted_output)
-        comprehensive_dictionary_csv = pd.read_csv(get_data_path("comprehensive_dictionary.csv"))
-        not_in_comprehensive = new_aliases[~new_aliases['mnemonics'].isin(comprehensive_dictionary_csv['mnemonics'])]
-        munge_df = not_in_comprehensive.copy().drop('label', axis=1)
-        munge_df['label'] = not_in_comprehensive['label'].str.upper()
-        appended_df = comprehensive_dictionary_csv.append(munge_df, ignore_index=True, verify_integrity=True)
+        comprehensive_dictionary_csv = pd.read_csv(
+            get_data_path("comprehensive_dictionary.csv")
+        )
+        not_in_comprehensive = new_aliases[
+            ~new_aliases["mnemonics"].isin(comprehensive_dictionary_csv["mnemonics"])
+        ]
+        munge_df = not_in_comprehensive.copy().drop("label", axis=1)
+        munge_df["label"] = not_in_comprehensive["label"].str.upper()
+        appended_df = comprehensive_dictionary_csv.append(
+            munge_df, ignore_index=True, verify_integrity=True
+        )
         if not path:
-            appended_df.to_csv(get_data_path("comprehensive_dictionary.csv"), index=False, columns=['mnemonics', 'label'])
+            appended_df.to_csv(
+                get_data_path("comprehensive_dictionary.csv"),
+                index=False,
+                columns=["mnemonics", "label"],
+            )
         else:
             if not path.endswith(".csv"):
                 raise IOError(
-                "Please check your file name type. Custom dictionary paths must end with .csv"
-            )
+                    "Please check your file name type. Custom paths must end with .csv"
+                )
             else:
-                appended_df.to_csv(path, index=False, columns=['mnemonics', 'label'])
-
+                appended_df.to_csv(path, index=False, columns=["mnemonics", "label"])

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -385,7 +385,7 @@ def test_add_to_dict_path():
     aliaser.add_to_dictionary(path=tmp_file)
     custom_dict = pd.read_csv(tmp_file)
     assert custom_dict.shape == (1285,2)
-    # os.remove(tmp_file)
+    os.remove(tmp_file)
 
 
 def test_add_fail_1():

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -35,6 +35,8 @@ Tests for Alaska's parser classes and functions
 """
 from pathlib import Path
 import matplotlib.pyplot as plt
+import pandas as pd
+import os
 import pytest
 import logging
 from ..keyword_tree import Alias, search, make_tree, search_child, Node
@@ -352,6 +354,59 @@ def test_heatmap():
     aliaser.parse(test_case_6)
     aliaser.heatmap()
     plt.gcf().canvas.draw()
+
+
+def test_add_to_dict():
+    """
+    Test that the add_to_dictionary method writes to the comprehensive dictionary
+    """
+    aliaser = Alias(
+        dictionary=True, keyword_extractor=True, model=True, prob_cutoff=0.85
+    )
+    aliaser.parse(test_case_6)
+    aliaser.add_to_dictionary()
+    path_to_comp_dict = get_data_path('comprehensive_dictionary.csv')
+    comprehensive = pd.read_csv(path_to_comp_dict)
+    assert comprehensive.shape == (1285,2)
+    comprehensive.drop([1281,1282,1283,1284])
+    # re-save the comprehensive dict without the new aliases
+    comprehensive.to_csv(path_to_comp_dict)
+
+
+def test_add_to_dict_path():
+    """
+    Test that the add_to_dictionary method writes to a custom path
+    """
+    aliaser = Alias(
+        dictionary=True, keyword_extractor=True, model=True, prob_cutoff=0.85
+    )
+    aliaser.parse(test_case_6)
+    tmp_file = test_dir_1 + 'custom_dict.csv'
+    aliaser.add_to_dictionary(path=tmp_file)
+    custom_dict = pd.read_csv(tmp_file)
+    assert custom_dict.shape == (1285,2)
+    os.remove(tmp_file)
+
+
+def test_add_fail_1():
+    """
+    Test that the add_to_dict prints error message for empty dict
+    """
+    aliaser = Alias(
+        dictionary=True, keyword_extractor=True, model=True, prob_cutoff=0.85
+    )
+    with pytest.raises(ValueError):
+        aliaser.add_to_dictionary(test_case_6)
+
+def test_add_fail_2():
+    """
+    Test that the add_to_dict prints error message for bad path (without .csv)
+    """
+    aliaser = Alias(
+        dictionary=True, keyword_extractor=True, model=True, prob_cutoff=0.85
+    )
+    with pytest.raises(IOError):
+        aliaser.add_to_dictionary(test_case_6, path=test_dir_1 +'bad_name')
 
 
 """

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -405,8 +405,9 @@ def test_add_fail_2():
     aliaser = Alias(
         dictionary=True, keyword_extractor=True, model=True, prob_cutoff=0.85
     )
+    aliaser.parse(test_case_6)
     with pytest.raises(IOError):
-        aliaser.add_to_dictionary(test_case_6, path=test_dir_1 +'bad_name')
+        aliaser.add_to_dictionary(path=test_dir_1 +'bad_name')
 
 
 """

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -34,11 +34,10 @@
 Tests for Alaska's parser classes and functions
 """
 from pathlib import Path
+import os
 import matplotlib.pyplot as plt
 import pandas as pd
-import os
 import pytest
-import logging
 from ..keyword_tree import Alias, search, make_tree, search_child, Node
 from ..predict_from_model import make_prediction
 from ..get_data_path import get_data_path
@@ -365,10 +364,10 @@ def test_add_to_dict():
     )
     aliaser.parse(test_case_6)
     aliaser.add_to_dictionary()
-    path_to_comp_dict = get_data_path('comprehensive_dictionary.csv')
+    path_to_comp_dict = get_data_path("comprehensive_dictionary.csv")
     comprehensive = pd.read_csv(path_to_comp_dict)
-    assert comprehensive.shape == (1285,2)
-    comprehensive.drop([1281,1282,1283,1284], inplace=True)
+    assert comprehensive.shape == (1285, 2)
+    comprehensive.drop([1281, 1282, 1283, 1284], inplace=True)
     # re-save the comprehensive dict without the new aliases
     comprehensive.to_csv(path_to_comp_dict)
 
@@ -381,10 +380,10 @@ def test_add_to_dict_path():
         dictionary=True, keyword_extractor=True, model=True, prob_cutoff=0.85
     )
     aliaser.parse(test_case_6)
-    tmp_file = str(test_dir_1) + '\\custom_dict.csv'
+    tmp_file = str(test_dir_1) + "\\custom_dict.csv"
     aliaser.add_to_dictionary(path=tmp_file)
     custom_dict = pd.read_csv(tmp_file)
-    assert custom_dict.shape == (1285,2)
+    assert custom_dict.shape == (1285, 2)
     os.remove(tmp_file)
 
 
@@ -398,6 +397,7 @@ def test_add_fail_1():
     with pytest.raises(ValueError):
         aliaser.add_to_dictionary(test_case_6)
 
+
 def test_add_fail_2():
     """
     Test that the add_to_dict prints error message for bad path (without .csv)
@@ -407,7 +407,7 @@ def test_add_fail_2():
     )
     aliaser.parse(test_case_6)
     with pytest.raises(IOError):
-        aliaser.add_to_dictionary(path=str(test_dir_1) +'bad_name')
+        aliaser.add_to_dictionary(path=str(test_dir_1) + "bad_name")
 
 
 """

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -381,11 +381,11 @@ def test_add_to_dict_path():
         dictionary=True, keyword_extractor=True, model=True, prob_cutoff=0.85
     )
     aliaser.parse(test_case_6)
-    tmp_file = test_dir_1 + 'custom_dict.csv'
+    tmp_file = str(test_dir_1) + '\\custom_dict.csv'
     aliaser.add_to_dictionary(path=tmp_file)
     custom_dict = pd.read_csv(tmp_file)
     assert custom_dict.shape == (1285,2)
-    os.remove(tmp_file)
+    # os.remove(tmp_file)
 
 
 def test_add_fail_1():
@@ -407,7 +407,7 @@ def test_add_fail_2():
     )
     aliaser.parse(test_case_6)
     with pytest.raises(IOError):
-        aliaser.add_to_dictionary(path=test_dir_1 +'bad_name')
+        aliaser.add_to_dictionary(path=str(test_dir_1) +'bad_name')
 
 
 """

--- a/alaska/tests/test_parser.py
+++ b/alaska/tests/test_parser.py
@@ -368,7 +368,7 @@ def test_add_to_dict():
     path_to_comp_dict = get_data_path('comprehensive_dictionary.csv')
     comprehensive = pd.read_csv(path_to_comp_dict)
     assert comprehensive.shape == (1285,2)
-    comprehensive.drop([1281,1282,1283,1284])
+    comprehensive.drop([1281,1282,1283,1284], inplace=True)
     # re-save the comprehensive dict without the new aliases
     comprehensive.to_csv(path_to_comp_dict)
 


### PR DESCRIPTION
I have added a method named `add_to_dictionary` to the `Alias` class that adds new aliases to `comprehensive_dictionary.csv`. 

This way the keyword extractor and the pointer generator can build out the dictionary lookup. Users will call the method with no arguments and it will update the comprehensive dictionary. Users can save a new comprehensive dictionary as a custom dictionary if they like. 

Also did some minor formatting and linting

Fixes #47 


**Reminders**

- [x] Run `black .` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
